### PR TITLE
Bugfix: Really check if analytics is loaded

### DIFF
--- a/dist/gtrack.js
+++ b/dist/gtrack.js
@@ -16,6 +16,7 @@ var _slicedToArray = function () { function sliceIterator(arr, i) { var _arr = [
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
 exports.init = init;
+exports.analyticsLoaded = analyticsLoaded;
 exports.parse = parse;
 exports.pageview = pageview;
 exports.event = event;
@@ -40,6 +41,13 @@ function init(opts) {
 
     ga('create', options.id, 'auto');
     ga('set', 'anonymizeIp', true);
+
+    ga(function () {
+        analyticsLoaded();
+    });
+}
+
+function analyticsLoaded() {
     pageview();
 
     if (options.removeUtm && location.search && history.replaceState) {

--- a/src/gtrack.js
+++ b/src/gtrack.js
@@ -15,6 +15,14 @@ export function init(opts) {
 
     ga('create', options.id, 'auto');
     ga('set', 'anonymizeIp', true);
+
+    ga(function() {
+        analyticsLoaded();
+    });
+}
+
+export function analyticsLoaded()
+{
     pageview();
 
     if (options.removeUtm && location.search && history.replaceState) {


### PR DESCRIPTION
This bugfix will really check if ```ga()``` is loaded.
Myself, I'm using Ghostery (chrome plugin) what blocks trackers like Analytics.

For example when using scrolling events, the ```event()``` method on ```ga()``` is beining called. This call causes some stuttering in the browser where the scrollbar gets an kind of offset.

This fix makes sure that ```ga()``` is loaded before continuing.